### PR TITLE
fix(presets): ignore nestjs lifecycle methods in dead_symbols (fixes #30)

### DIFF
--- a/presets/nestjs.yaml
+++ b/presets/nestjs.yaml
@@ -11,6 +11,12 @@ rules:
   layer_violation: high
   module_cohesion: off
   dead_symbols:
+    ignore_methods:
+      - onModuleInit
+      - onModuleDestroy
+      - onApplicationBootstrap
+      - beforeApplicationShutdown
+      - onApplicationShutdown
     contract_methods:
       OnModuleInit: ['onModuleInit']
       OnApplicationBootstrap: ['onApplicationBootstrap']


### PR DESCRIPTION
Add NestJS lifecycle methods (onModuleInit, onModuleDestroy, etc.) to the ignore_methods list in the nestjs preset to prevent them from being incorrectly flagged as dead symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated NestJS preset configuration to exclude lifecycle methods from dead symbol detection, preventing false positives when analyzing NestJS applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->